### PR TITLE
Use subtract instead of substract

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,20 +121,20 @@ Generates random vector with a length of 1. Optional argument can be passed to s
 let vec = new Vector();
 vec.random();//possibly: {x: -0.23372631348780365, y: 0.9723024274285244}
 ```
-### substract(vector1 [, vectorN])
-Substract one or more vectors. Returns self so can be chained.
+### subtract(vector1 [, vectorN])
+Subtract one or more vectors. Returns self so can be chained.
 ```javascript
 let vec = new Vector(50, 50);
 let another = new Vector(10, 5);
-vec.substract(another);//{x: 40, y: 45}
+vec.subtract(another);//{x: 40, y: 45}
 ```
-### substraction(vector1, vector2)
-Sets vector value to the substraction of two vectors. Doesn't mutate the vectors passed as arguments. Returns self so can be chained.
+### subtraction(vector1, vector2)
+Sets vector value to the subtraction of two vectors. Doesn't mutate the vectors passed as arguments. Returns self so can be chained.
 ```javascript
 let vec = new Vector();
 let other = new Vector(100, 100);
 let another = new Vector(5, 5);
-vec.substraction(another, other);//{x: -95, y: 95}
+vec.subtraction(another, other);//{x: -95, y: 95}
 ```
 ### scaledAdd(scale, vector1 [, vectorN])
 Add one or more vectors while multiplying the vectors by given scalar. Doesn't mutate vectors passed as arguments. Returns self so can be chained.

--- a/Vector.js
+++ b/Vector.js
@@ -93,7 +93,7 @@ export default class Vector {
 	}
 
   setFromTo(from, to) {
-    return this.set(to).substract(from);
+    return this.set(to).subtract(from);
   }
 
   add(...args) {
@@ -122,7 +122,7 @@ export default class Vector {
     return this.set(l, 0).rotate(Math.random() * Math.PI * 2);
   }
 
-  substract(...args) {
+  subtract(...args) {
     args.forEach(v => {
       this.x -= v.x;
       this.y -= v.y;
@@ -130,7 +130,7 @@ export default class Vector {
     return this;
   }
 
-  substraction(a, b) {
+  subtraction(a, b) {
     return this.set(a.x - b.x, a.y - b.y);
   }
 


### PR DESCRIPTION
Hi there,

thank you for creating this useful library!
This pull request changes all uses of `substract` to `subtract` which I think is more commonly used.